### PR TITLE
Update for Laravel 5.8+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
-        "illuminate/support": "^5.3",
+        "php": ">=7.1.3",
+        "illuminate/support": "^5.8|^6.0|^7.0",
         "friendsofphp/php-cs-fixer": "^2.13"
     },
     "require-dev": {
-        "illuminate/console": "^5.3"
+        "illuminate/console": "^5.8|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ArtisanPhpCsFixerServiceProvider.php
+++ b/src/ArtisanPhpCsFixerServiceProvider.php
@@ -1,5 +1,6 @@
 <?php namespace Jackiedo\ArtisanPhpCsFixer;
 
+use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use Jackiedo\ArtisanPhpCsFixer\Console\Commands\ArtisanPhpCsFixerFix;
 use Jackiedo\ArtisanPhpCsFixer\Console\Commands\ArtisanPhpCsFixerVersion;
@@ -12,16 +13,8 @@ use Jackiedo\ArtisanPhpCsFixer\Console\Commands\ArtisanPhpCsFixerReadme;
  * @package Jackiedo\ArtisanPhpCsFixer
  * @author  Jackie Do <anhvudo@gmail.com>
  */
-class ArtisanPhpCsFixerServiceProvider extends ServiceProvider
+class ArtisanPhpCsFixerServiceProvider extends ServiceProvider implements DeferrableProvider
 {
-
-    /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = true;
-
     /**
      * Bootstrap the application events.
      *


### PR DESCRIPTION
- Added support for Laravel versions from 5.8 to the 7.x
- Updated defer the loading of providers for Laravel 5.8+